### PR TITLE
GH-8: Setup CODEOWNERS

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code Owners - for default reviewers on GitHub
+
+# Lucas Combs
+*   @lcombs15
+
+# Liam Tiemon
+*   @tiemonl


### PR DESCRIPTION
* Should work for default GitHub reviewers