### PR TITLE
GH-8: Setup CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code Owners - for default reviewers on GitHub
+
+# Lucas Combs & Liam Tiemon
+*   @lcombs15 @tiemonl


### PR DESCRIPTION
* Should work for default GitHub reviewers